### PR TITLE
Block users and activities on report creation

### DIFF
--- a/functions/src/blocking.ts
+++ b/functions/src/blocking.ts
@@ -5,29 +5,71 @@ try { admin.initializeApp() } catch (e) {}
 
 const db = admin.firestore();
 
-export async function blockUser(blocker_id: string, blocked_id: string): Promise<void> {
+export async function block(type: string, blocker_id: string, blocked_id: string): Promise<void> {
+
     //use a batch to atomically update both users, works offline
     var batch = db.batch();
-    var blockerRef = db.collection("users").doc(blocker_id);
-    var blockedRef = db.collection("users").doc(blocked_id);
+    
+    if(type == "user"){
+        const blockerRef = db.collection("users").doc(blocker_id);
+        const blockedRef = db.collection("users").doc(blocked_id);
 
-    batch.update(blockerRef, {
-        blocked_users: admin.firestore.FieldValue.arrayUnion(blocked_id)
-    });
-    batch.update(blockedRef, {
-        blocked_by: admin.firestore.FieldValue.arrayUnion(blocker_id)
-    });
+        batch.update(blockedRef, {
+            blocked_by: admin.firestore.FieldValue.arrayUnion(blocker_id)
+        });
+
+        batch.update(blockerRef, {
+            blocked_users: admin.firestore.FieldValue.arrayUnion(blocked_id)
+        });
+    } else if (type == "activity"){
+        const blockerRef = db.collection("users").doc(blocker_id);
+        batch.update(blockerRef, {
+            blocked_activities: admin.firestore.FieldValue.arrayUnion(blocked_id)
+        });
+    }
 
     try {
         await batch.commit();
-        console.log(`${blocker_id} successfully blocked ${blocked_id}`);
+        console.log(`User ${blocker_id} successfully blocked the ${type} ${blocked_id}`);
     } catch(e) {
-        console.error(`${blocker_id} failed blocking ${blocked_id}`);
+        console.error(`User ${blocker_id} failed blocking ${type} ${blocked_id}`);
         console.error(e);
         throw e;
     }
 }
 
 export const blockUserOnCall = functions.https.onCall(async (data, context) => {
-    await blockUser(data.blocker_id, data.blocked_id);
+    await block('user', data.blocker_id, data.blocked_id);
 })
+
+export function getReportIds(actorField: string, targetField: string, snap: FirebaseFirestore.DocumentSnapshot){
+    const newReport = snap.data();
+    const actor_id = newReport ? newReport[actorField] : null;
+    const target_id = newReport ? newReport[targetField] : null;
+    return { actor_id, target_id };
+}
+
+
+export const newReportedUser = functions.firestore
+    .document('user_report/{reportId}').onCreate(async (snap, context) => {
+        const { actor_id, target_id } = getReportIds('report_by_id', 'reported_user_id', snap);
+        if(actor_id && target_id){
+            await block('user', actor_id, target_id);
+        } else {
+            console.error(`Blocker "${actor_id}" or blocked "${target_id}" does not exist`);
+        }
+    });
+
+
+
+export const newReportedActivity = functions.firestore
+    .document('activity_report/{reportId}').onCreate(async (snap, context) => {
+        const { actor_id, target_id } = getReportIds('report_by_id', 'reported_activity_id', snap);
+        if(actor_id && target_id){
+            await block('activity', actor_id, target_id);
+        } else {
+            console.error(`Blocker "${actor_id}" or blocked "${target_id}" does not exist`);
+        }
+    });
+
+

--- a/functions/src/blocking.ts
+++ b/functions/src/blocking.ts
@@ -9,7 +9,7 @@ export async function block(type: string, blocker_id: string, blocked_id: string
 
     //use a batch to atomically update both users, works offline
     var batch = db.batch();
-    
+
     if(type == "user"){
         const blockerRef = db.collection("users").doc(blocker_id);
         const blockedRef = db.collection("users").doc(blocked_id);
@@ -30,7 +30,6 @@ export async function block(type: string, blocker_id: string, blocked_id: string
 
     try {
         await batch.commit();
-        console.log(`User ${blocker_id} successfully blocked the ${type} ${blocked_id}`);
     } catch(e) {
         console.error(`User ${blocker_id} failed blocking ${type} ${blocked_id}`);
         console.error(e);

--- a/functions/src/test/blocking.test.ts
+++ b/functions/src/test/blocking.test.ts
@@ -1,47 +1,119 @@
 import * as assert from 'assert';
 import * as admin from 'firebase-admin';
 import 'mocha';
-
 import * as blocking from '../blocking';
+import { FeaturesList } from 'firebase-functions-test/lib/features';
+import { getTestFeatureList } from './config';
 
-const test = require('firebase-functions-test')({
-    databaseURL: "https://beans-buddies-dev.firebaseio.com",
-    storageBucket: "beans-buddies-dev.appspot.com",
-    projectId: "beans-buddies-dev",
-}, 'beans-buddies-dev.json.secret');
+describe("Block function", () => {
 
-describe("Block User Typescript func", () => {
-    let db: FirebaseFirestore.Firestore;
-    before(async ()=>{
-        db = admin.firestore();
-        await db.collection('users').doc("blocker_guy").set({"name": "blocker_guy"});
-        await db.collection('users').doc("blocked_guy").set({"name": "blocked_guy"});
+    describe("Block User Typescript func", () => {
+        let db: FirebaseFirestore.Firestore, test : FeaturesList;
+        
+        before(async ()=>{
+            test = getTestFeatureList();
+            db = admin.firestore();
+            await db.collection('users').doc("blocker_guy").set({"name": "our blocker_guy"});
+            await db.collection('users').doc("blocked_guy").set({"name": "our blocked_guy"});
+        })
+
+        after(()=> { test.cleanup(); })
+
+        it("Blocking denormalizes for an arbitrary blocker and blockee", async ()=>{
+            await blocking.block('user', "blocker_guy", "blocked_guy");
+
+            const blockerDoc = await db.collection('users').doc("blocker_guy").get();
+            const blockedDoc = await db.collection('users').doc("blocked_guy").get();
+        
+            const blockerData = blockerDoc.data();
+            const blockedData = blockedDoc.data();
+
+            assert(!blockerData!.blocked_by); 
+            assert.deepEqual(blockerData!.blocked_users, ["blocked_guy"]); 
+
+            assert(!blockedData!.blocked_users)
+            assert.deepEqual(blockedData!.blocked_by, ["blocker_guy"]); 
+        })
+
     })
 
-    after(() => {
-        // db.collection('users').doc("blocker_guy").delete();
-        // db.collection('users').doc("blocked_guy").delete();
-        test.cleanup();
-    });
+    describe("Block User Typescript func", () => {
+        let db: FirebaseFirestore.Firestore, test : FeaturesList;
+        before(async ()=>{
+            test = getTestFeatureList();
+            db = admin.firestore();
+            await db.collection('users').doc("blocker_guy").set({"name": "our blocker_guy"});
+            await db.collection('activities').doc("blocked_activity").set({"name": "our blocked_activity"});
+        })
 
-    it("Blocking denormalizes for an arbitrary blocker and blockee", async ()=>{
+        after(()=> { test.cleanup(); })
 
-        await blocking.blockUser("blocker_guy", "blocked_guy");
+        it("Blocking denormalizes for an arbitrary blocker and blockee", async ()=>{
+            await blocking.block('activity', "blocker_guy", "blocked_activity");
 
-        const blockerDoc = await db.collection('users').doc("blocker_guy").get();
-        const blockedDoc = await db.collection('users').doc("blocked_guy").get();
+            const blockerDoc = await db.collection('users').doc("blocker_guy").get();
+            const blockerData = blockerDoc.data();
+
+            assert(!blockerData!.blocked_by); 
+            assert.deepEqual(blockerData!.blocked_activities, ["blocked_activity"]); 
+        })
+
+
+    })
     
-        const blockerData = blockerDoc.data();
-        const blockedData = blockedDoc.data();
+})
 
-
-        assert(!blockerData!.blocked_by); 
-        assert.deepEqual(blockerData!.blocked_users, ["blocked_guy"]); 
-
-        assert(!blockedData!.blocked_users)
-        assert.deepEqual(blockedData!.blocked_by, ["blocker_guy"]); 
-
+describe("IDs are properly taken from snapshots", () => {
+    describe("Users are blocked with a created report", () => {
+        let test: FeaturesList
+    
+        before(()=>{
+            test = getTestFeatureList();
+        })
+    
+        after(()=> {
+            test.cleanup();
+        })
+    
+        it("Reports use correct IDs to call the block user procecure", ()=>{
+            const data = {
+                "report_by_id": "reporter_user",
+                "reported_user_id": "reported_user",
+            }
+            const newReport = test.firestore.makeDocumentSnapshot(data, 'user_report/test_report');
+    
+            let { actor_id, target_id } = blocking.getReportIds('report_by_id', 'reported_user_id', newReport);
+            assert(actor_id == "reporter_user");
+            assert(target_id == "reported_user")
+        })
     })
 
+    describe("Users are blocked with a created report", () => {
+        let test: FeaturesList
+    
+        before(()=>{
+            test = getTestFeatureList();
+        })
+    
+        after(()=> {
+            test.cleanup();
+        })
+    
+        it("Reports use correct IDs to call the block user procecure", ()=>{
+            const data = {
+                "report_by_id": "reporter_user",
+                "reported_activity_id": "reported_activity",
+            }
+            const newReport = test.firestore.makeDocumentSnapshot(data, 'user_report/test_report');
+    
+            let { actor_id, target_id } = blocking.getReportIds('report_by_id', 'reported_activity_id', newReport);
+            assert(actor_id == "reporter_user");
+            assert(target_id == "reported_activity")
+        })
+    })
 })
+
+
+
+
 

--- a/functions/src/test/config.ts
+++ b/functions/src/test/config.ts
@@ -1,0 +1,9 @@
+import * as firebase_test from 'firebase-functions-test';
+
+export function getTestFeatureList() { 
+    return firebase_test({
+        databaseURL: "https://beans-buddies-dev.firebaseio.com",
+        storageBucket: "beans-buddies-dev.appspot.com",
+        projectId: "beans-buddies-dev",
+    }, 'beans-buddies-dev.json.secret');
+}


### PR DESCRIPTION
On a `report_activity` or `report_user` document creation, the acting reporter will now block the target user or activity.

Tests cover helper functions, but not the actual triggering of the Cloud functions.