### PR TITLE
Some small lint issues for deploy

### DIFF
--- a/functions/src/algoliaSync.ts
+++ b/functions/src/algoliaSync.ts
@@ -5,7 +5,7 @@ import { algoliaMock } from './test/mocks'
 
 // Algolia Setup:
 const isTestMode = process.env.NODE_ENV === 'test'
-const client = isTestMode ? algoliaMock() : algoliasearch(constants.ALGOLIA_APP_ID, constants.ALGOLIA_SEARCH_API_KEY)
+const client = isTestMode ? algoliaMock() : algoliasearch(constants.ALGOLIA_APP_ID, constants.ALGOLIA_ADMIN_API_KEY)
 
 // Triggered on create, update, and delete:
 export function activityDataHandler (change: functions.Change<FirebaseFirestore.DocumentSnapshot>, context: functions.EventContext) {

--- a/functions/src/blocking.ts
+++ b/functions/src/blocking.ts
@@ -10,7 +10,7 @@ export async function block(type: string, blocker_id: string, blocked_id: string
     //use a batch to atomically update both users, works offline
     const batch = db.batch();
 
-    if(type == "user"){
+    if(type === "user"){
         const blockerRef = db.collection("users").doc(blocker_id);
         const blockedRef = db.collection("users").doc(blocked_id);
 
@@ -21,7 +21,7 @@ export async function block(type: string, blocker_id: string, blocked_id: string
         batch.update(blockerRef, {
             blocked_users: admin.firestore.FieldValue.arrayUnion(blocked_id)
         });
-    } else if (type == "activity"){
+    } else if (type === "activity"){
         const blockerRef = db.collection("users").doc(blocker_id);
         batch.update(blockerRef, {
             blocked_activities: admin.firestore.FieldValue.arrayUnion(blocked_id)

--- a/functions/src/test/blocking.test.ts
+++ b/functions/src/test/blocking.test.ts
@@ -82,9 +82,9 @@ describe("IDs are properly taken from snapshots", () => {
             }
             const newReport = test.firestore.makeDocumentSnapshot(data, 'user_report/test_report');
     
-            let { actor_id, target_id } = blocking.getReportIds('report_by_id', 'reported_user_id', newReport);
-            assert(actor_id == "reporter_user");
-            assert(target_id == "reported_user")
+            const { actor_id, target_id } = blocking.getReportIds('report_by_id', 'reported_user_id', newReport);
+            assert(actor_id === "reporter_user");
+            assert(target_id === "reported_user")
         })
     })
 
@@ -106,9 +106,9 @@ describe("IDs are properly taken from snapshots", () => {
             }
             const newReport = test.firestore.makeDocumentSnapshot(data, 'user_report/test_report');
     
-            let { actor_id, target_id } = blocking.getReportIds('report_by_id', 'reported_activity_id', newReport);
-            assert(actor_id == "reporter_user");
-            assert(target_id == "reported_activity")
+            const { actor_id, target_id } = blocking.getReportIds('report_by_id', 'reported_activity_id', newReport);
+            assert(actor_id === "reporter_user");
+            assert(target_id === "reported_activity")
         })
     })
 })

--- a/functions/tslint.json
+++ b/functions/tslint.json
@@ -111,7 +111,7 @@
     "prefer-const": {"severity": "warning"},
 
     // Multi-line object literals and function calls should have a trailing comma. This helps avoid merge conflicts.
-    "trailing-comma": {"severity": "warning"},
+    "trailing-comma": {"severity": "warning"}
   },
 
   "defaultSeverity": "error"


### PR DESCRIPTION
Firebase runs tslint before deploying, so it wouldn't let me deploy right away. Just an FYI for the future

1. it doesn't like when you use `let` when you could have used `const`. (use const whenever the variable doesn't get re-assigned)
2. It doesn't like when you could have used `===`. The one edge case that is `== null` for checking null & undefined in one go.

Also there was this DUMB issue in the Tslint file. It didn't like that comma.
![screen shot 2019-01-30 at 7 18 13 pm](https://user-images.githubusercontent.com/6265975/52021803-69479680-24c4-11e9-80ef-8022ab5e59ba.png)

Anyways, with these changes, the functions deploy.