### PR TITLE
BUD-31, BUD-28: Respect user preferences in chat notifications

### DIFF
--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -177,10 +177,13 @@ export async function getTokensForChatNotification(userIds: string[], senderId: 
     // Get the notification token for each user if the user exists and if the token
     // is a string that is not empty.
     const tokens = userDocs.reduce((val: string[], doc: FirebaseFirestore.DocumentSnapshot) => {
-        if (doc.exists) {
-            const data = doc.data()
-            const token = data && data.notification_token ? data.notification_token : null
-            if (token && typeof token === 'string' && token.length > 0) {
+        const data = doc.data()
+        if (doc.exists && data) {
+            const token = data.notification_token ? data.notification_token : null
+            // If users notification preference is defined, use it. Otherwise, default the preference to true.
+            const notificationPref = data.should_send_joined_activity_notification != null ? data.should_send_joined_activity_notification : true
+            if (token && typeof token === 'string' && token.length > 0 && notificationPref) {
+                // Only add the token if the user has a valid token, and if the user is ok with receiving notifications.
                 val.push(token)
             }
         }

--- a/functions/src/test/mocks.ts
+++ b/functions/src/test/mocks.ts
@@ -194,10 +194,10 @@ export const mockActivity = {
 export const mockUsers = {
     bob: {
         notification_token: 'bob_t',
-        name: 'BOB THE BUILDER'
+        name: 'BOB THE BUILDER',
     },
     alice: {
-        notification_token: 'alice_t'
+        notification_token: 'alice_t',
     },
     mallory: {
         notification_token: 'mallory_t'
@@ -210,6 +210,14 @@ export const mockUsers = {
     },
     ste5en: {
         notification_token: 10
+    },
+    guy: {
+        should_send_joined_activity_notification: false,
+        notification_token: 'guy_t',
+    },
+    guy2: {
+        should_send_joined_activity_notification: true,
+        notification_token: 'guy_2',
     }
 }
 

--- a/functions/src/test/notifications.test.ts
+++ b/functions/src/test/notifications.test.ts
@@ -231,6 +231,30 @@ describe('Notifications', () => {
             const res = await notifications.getTokensForChatNotification(userIds, senderId, db)
             assert.deepEqual(res, ['bob_t', 'alice_t'])
         })
+        it('Excludes users who have turned off activity detail notifications', async () => {
+            const userIds = ['alice', 'guy', 'bob'] // Guy has turned off notifications
+            const senderId = 'alice'
+            const db = mocks.firestoreMock
+            // @ts-ignore because our mock is fine
+            const res = await notifications.getTokensForChatNotification(userIds, senderId, db)
+            assert.deepEqual(res, ['bob_t'])
+        })
+        it('Includes users who do not have a notification preference set', async () => {
+            const userIds = ['alice', 'bob'] // Bob does not have a preference defined
+            const senderId = 'alice'
+            const db = mocks.firestoreMock
+            // @ts-ignore because our mock is fine
+            const res = await notifications.getTokensForChatNotification(userIds, senderId, db)
+            assert.deepEqual(res, ['bob_t'])
+        })
+        it('Includes users who have agreed to activity detail notifications', async () => {
+            const userIds = ['alice', 'guy2',] // Guy2 has allowed notifications
+            const senderId = 'alice'
+            const db = mocks.firestoreMock
+            // @ts-ignore because our mock is fine
+            const res = await notifications.getTokensForChatNotification(userIds, senderId, db)
+            assert.deepEqual(res, ['guy_2'])
+        })
     })
     
     describe('Chat notification factory', () => {


### PR DESCRIPTION
We have two notifications defined right now:

1. A notification for activities created nearby
2. A notification for new chat messages to an activity you're a part of. This includes members joining and leaving.

Item 1 already respects notification preferences (BUD-28). This adds support for number 2 with a check for the notification preference in user data before adding their token to the notifications.

Both should be fully tested for edge cases including: preference set to false, preference set to true, preference does not exist (in which case we consider it to be true by default). 