### PR TITLE
Delete the user's firestore data and profile picture when their account is deleted.

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,3 +16,6 @@ export const onMessageCreation = functions.firestore.document('activities/{activ
 import * as algoliaSync from './algoliaSync'
 export const sendActivityDataToAlgolia = functions.firestore.document('activities/{activity_id}').onWrite(algoliaSync.activityDataHandler)
 export const sendUserDataToAlgolia = functions.firestore.document('users/{user_id}').onWrite(algoliaSync.userDataHandler)
+
+import * as userManagement from './userManagement'
+export const onUserDelete = functions.auth.user().onDelete(userManagement.onUserDelete)

--- a/functions/src/test/mocks.ts
+++ b/functions/src/test/mocks.ts
@@ -213,6 +213,14 @@ export const mockUsers = {
     }
 }
 
+export const storageBucketMock = {
+    file: (path: String) => ({
+         // We can pass 'not_exist' as the UID to test if a file exists:
+        exists: () => Promise.resolve(path.split('/').indexOf('not_exists') === -1),
+        delete: () => { exports.spyOnMe2(); Promise.resolve(true) }
+    })
+}
+
 export const firestoreMock = {
     collection: (id: string) => {
         if (id === 'activities') {
@@ -224,6 +232,10 @@ export const firestoreMock = {
         }
     }
 }
+
+// These are just for spying:
+export const spyOnMe1 = () => 1
+export const spyOnMe2 = () => 2
 
 function collectionGenerator(data: {[id: string]: Object}) {
     return {
@@ -238,7 +250,8 @@ function collectionGenerator(data: {[id: string]: Object}) {
             },
             collection: (i: string) => ({
                 add: (d: any) => Promise.resolve(d)
-            })
+            }),
+            delete: () => { exports.spyOnMe1(); Promise.resolve(true) }
         }),
         add: (d: any) => Promise.resolve(d)
     }

--- a/functions/src/test/userManagement.test.ts
+++ b/functions/src/test/userManagement.test.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import * as mocks from './mocks'
+import 'mocha'
+
+import * as userManagement from '../userManagement'
+
+describe('User Management', () => {
+  describe('On user delete', () => {
+    it('Deletes the Firestore document for the user', async () => {
+      const dbSpy = sinon.spy(mocks, 'spyOnMe1')
+      const testUser = {
+        uid: 'hello'
+      }
+      // @ts-ignore
+      await userManagement.onUserDelete(testUser, {})
+      assert(dbSpy.calledOnce)
+      dbSpy.restore()
+    })
+    it('Deletes their profile picture if it exists', async () => {
+      const fileSpy = sinon.spy(mocks, 'spyOnMe2')
+      const testUser = {
+        uid: 'bob_builder'
+      }
+      // @ts-ignore
+      await userManagement.onUserDelete(testUser, {})
+      assert(fileSpy.calledOnce)
+      fileSpy.restore()
+    })
+    it('Does not try to delete their profile picture if it does not exist', async () => {
+      const fileSpy = sinon.spy(mocks, 'spyOnMe2')
+      const testUser = {
+        uid: 'not_exists'
+      }
+      // @ts-ignore
+      await userManagement.onUserDelete(testUser, {})
+      assert(fileSpy.notCalled)
+      fileSpy.restore()
+    })
+  })
+})

--- a/functions/src/userManagement.ts
+++ b/functions/src/userManagement.ts
@@ -19,7 +19,6 @@ export async function onUserDelete (user: admin.auth.UserRecord, context: functi
   await databaseRef.delete()
   const exists = await pictureRef.exists()
   if (exists) {
-    console.log('RIGHT HERE')
     await pictureRef.delete()
   }
 }

--- a/functions/src/userManagement.ts
+++ b/functions/src/userManagement.ts
@@ -1,0 +1,25 @@
+import * as functions from 'firebase-functions'
+import * as admin from 'firebase-admin'
+import { storageBucketMock, firestoreMock } from './test/mocks'
+import Refs from './firestoreRefs'
+import * as _ from 'lodash'
+
+try { admin.initializeApp() } catch (e) {}
+
+const isTestMode = process.env.NODE_ENV === 'test'
+const database = isTestMode ? firestoreMock : admin.firestore()
+const storageBucket = isTestMode ? storageBucketMock : admin.storage().bucket()
+
+export async function onUserDelete (user: admin.auth.UserRecord, context: functions.EventContext) {
+  const uid = user.uid
+  // @ts-ignore for the mock
+  const databaseRef = Refs(database).user(uid)
+  const pictureRef = storageBucket.file(`users/${uid}/profilePicture.jpg`)
+
+  await databaseRef.delete()
+  const exists = await pictureRef.exists()
+  if (exists) {
+    console.log('RIGHT HERE')
+    await pictureRef.delete()
+  }
+}


### PR DESCRIPTION
This function runs whenever a `firebase.auth()` account is deleted. It deletes the corresponding Firestore document for that user, and also deletes their uploaded profile picture if they have one.