### PR TITLE
Handle deleting account data on doc deletion

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -29,6 +29,7 @@ export const sendUserDataToAlgolia = functions.firestore.document('accounts/{use
 export const onActivityDelete = functions.firestore.document('activities/{activity_id}').onDelete(algoliaSync.onActivityDelete)
 
 import UserManagement from './userManagement'
-const userManagement = new UserManagement(admin.firestore(), admin.storage().bucket())
+const userManagement = new UserManagement(admin.firestore(), admin.storage().bucket(), admin.auth())
 export const onUserDelete = functions.auth.user().onDelete(userManagement.onUserDelete)
+export const onUserDocDelete = functions.firestore.document('accounts/{user_id}').onDelete(userManagement.onUserDocDelete)
 export const onAccountChange = functions.firestore.document("accounts/{user_id}").onWrite(userManagement.onAccountChangePush)

--- a/functions/src/test/mocks.ts
+++ b/functions/src/test/mocks.ts
@@ -6,6 +6,11 @@ export const adminMock = () => ({
     messaging: () => messagingMock
 })
 
+export const authMock = {
+    getUser: (uid: string) => Promise.resolve(),
+    deleteUser: (uid: string) => Promise.resolve()
+}
+
 export const testUsersNoteAndBlock: AlgoliaUser[] = [
     { // Remove because there is no token:
         objectID: '1',

--- a/functions/src/test/userManagement.test.ts
+++ b/functions/src/test/userManagement.test.ts
@@ -5,37 +5,58 @@ import 'mocha'
 
 import UserManagement from '../userManagement'
 // @ts-ignore
-const userManagement = new UserManagement(mocks.firestoreMock, mocks.storageBucketMock)
+const userManagement = new UserManagement(mocks.firestoreMock, mocks.storageBucketMock, mocks.authMock)
 
 describe('User Management', () => {
   describe('On user delete', () => {
-    it('Deletes the Firestore document for the user', async () => {
+    it('Deletes their private doc', async () => {
       const dbSpy = sinon.spy(mocks, 'spyOnMe1')
       const testUser = {
         uid: 'hello'
       }
-      // @ts-ignore
       await userManagement.onUserDelete(testUser, {})
-      assert(dbSpy.calledTwice)
+      assert(dbSpy.calledOnce)
       dbSpy.restore()
     })
+  })
+  describe('On user private doc delete', () => {
+    it('Deletes the public document for the user', async () => {
+      const dbSpy = sinon.spy(userManagement, 'deletePublicAccount')
+      const testUser = { id: 'hello' }
+      await userManagement.onUserDocDelete(testUser, {})
+      assert(dbSpy.calledOnce)
+      dbSpy.restore()
+    })
+    it('Deletes their profile picture', async () => {
+      const fileSpy = sinon.spy(userManagement, 'deleteUserPicture')
+      const testUser = { id: 'hello' }
+      await userManagement.onUserDocDelete(testUser, {})
+      assert(fileSpy.calledOnce)
+      fileSpy.restore()
+    })
+  })
+  describe('Delete public account', () => {
+    it('Deletes the public record for the given UID', () => {
+      it('Deletes their public doc', async () => {
+        const dbSpy = sinon.spy(mocks, 'spyOnMe1')
+        await userManagement.deletePublicAccount('hello')
+        assert(dbSpy.calledOnce)
+        dbSpy.restore()
+      })
+    })
+  })
+  describe('Delete user picture', () => {
     it('Deletes their profile picture if it exists', async () => {
       const fileSpy = sinon.spy(mocks, 'spyOnMe2')
-      const testUser = {
-        uid: 'bob_builder'
-      }
-      // @ts-ignore
-      await userManagement.onUserDelete(testUser, {})
+      const testUser = { id: 'hello' }
+      await userManagement.onUserDocDelete(testUser, {})
       assert(fileSpy.calledOnce)
       fileSpy.restore()
     })
     it('Does not try to delete their profile picture if it does not exist', async () => {
       const fileSpy = sinon.spy(mocks, 'spyOnMe2')
-      const testUser = {
-        uid: 'not_exists'
-      }
-      // @ts-ignore
-      await userManagement.onUserDelete(testUser, {})
+      const testUser = { id: 'not_exists' }
+      await userManagement.onUserDocDelete(testUser, {})
       assert(fileSpy.notCalled)
       fileSpy.restore()
     })


### PR DESCRIPTION
Previously, it only handled auth creation. This makes sure that if we delete a document under `accounts` in firestore, it will delete all of that user's other info as well. 

I avoided race conditions by only deleting the user's "account" doc when their auth account is deleted. This adds the cloud function that, when it sees that the account doc has been deleted, also deletes their public "users" doc and their profile picture if it exists. Additionally, it will attempt to delete their auth account if it still exists.

This means that we can delete a user's "account" doc, and everything will be cleaned up properly, which was not previously the case.

However, deleting the doc under "users"  will not affect anything.