### PR TITLE
Remove current user from shared activities when blocking

### DIFF
--- a/functions/src/Types.ts
+++ b/functions/src/Types.ts
@@ -38,6 +38,7 @@ interface Activity {
     end_time : Date
     topic_ids : string[]
     date_created : Date
+    banned_users: string[]
 }
 
 interface ChatMessage {

--- a/functions/src/blocking.ts
+++ b/functions/src/blocking.ts
@@ -1,108 +1,106 @@
-import * as functions from 'firebase-functions'
+import { EventContext } from 'firebase-functions'
+import { CallableContext } from 'firebase-functions/lib/providers/https'
 import * as admin from 'firebase-admin'
 import Ref from './firestoreRefs'
 import { get, includes } from 'lodash'
 
-// import refs from '../../firestoreRefs.js'
-try { admin.initializeApp() } catch (e) {}
+export default class Blocking {
+    constructor(public db: FirebaseFirestore.Firestore) { }
 
-const db = admin.firestore();
+    block = async (type: 'user' | 'activity', blocker_id: string, blocked_id: string) => {
 
-export async function block(type: 'user' | 'activity', blocker_id: string, blocked_id: string): Promise<void> {
-
-    //use a batch to atomically update both users, works offline
-    const batch = db.batch();
-
-    const refs = Ref(db);
-
-    if(type === "user"){
-        const blockerRef = refs.account(blocker_id);
-        const blockedRef = refs.account(blocked_id);
-
-        batch.update(blockedRef, {
-            blocked_by: admin.firestore.FieldValue.arrayUnion(blocker_id)
-        });
-
-        batch.update(blockerRef, {
-            blocked_users: admin.firestore.FieldValue.arrayUnion(blocked_id)
-        });
-    } else if (type === "activity"){
-        const blockerRef = refs.account(blocker_id);
-        batch.update(blockerRef, {
-            blocked_activities: admin.firestore.FieldValue.arrayUnion(blocked_id)
-        });
+        //use a batch to atomically update both users, works offline
+        const batch = this.db.batch();
+    
+        const refs = Ref(this.db);
+    
+        if(type === "user"){
+            const blockerRef = refs.account(blocker_id);
+            const blockedRef = refs.account(blocked_id);
+    
+            batch.update(blockedRef, {
+                blocked_by: admin.firestore.FieldValue.arrayUnion(blocker_id)
+            });
+    
+            batch.update(blockerRef, {
+                blocked_users: admin.firestore.FieldValue.arrayUnion(blocked_id)
+            });
+        } else if (type === "activity"){
+            const blockerRef = refs.account(blocker_id);
+            batch.update(blockerRef, {
+                blocked_activities: admin.firestore.FieldValue.arrayUnion(blocked_id)
+            });
+        }
+    
+        try {
+            await batch.commit();
+        } catch(e) {
+            console.error(`User ${blocker_id} failed blocking ${type} ${blocked_id}`);
+            console.error(e);
+            throw e;
+        }
     }
 
-    try {
-        await batch.commit();
-    } catch(e) {
-        console.error(`User ${blocker_id} failed blocking ${type} ${blocked_id}`);
-        console.error(e);
-        throw e;
+    blockUserOnCall = async (data: any, context: CallableContext) => {
+        await this.block('user', data.blocker_id, data.blocked_id);
     }
-}
 
-export const blockUserOnCall = functions.https.onCall(async (data, context) => {
-    await block('user', data.blocker_id, data.blocked_id);
-})
-
-export function getReportIds(actorField: string, targetField: string, snap: FirebaseFirestore.DocumentSnapshot){
-    const newReport = snap.data();
-    const actor_id = newReport ? newReport[actorField] : null;
-    const target_id = newReport ? newReport[targetField] : null;
-    return { actor_id, target_id };
-}
-
-export const newReportedUser = functions.firestore
-    .document('user_report/{reportId}').onCreate(async (snap, context) => {
-        const { actor_id, target_id } = getReportIds('report_by_id', 'reported_user_id', snap);
+    newReportedUser = async (snap: FirebaseFirestore.DocumentSnapshot, context: EventContext) => {
+        const { actor_id, target_id } = this.getReportIds('report_by_id', 'reported_user_id', snap);
         if(actor_id && target_id){
-            await block('user', actor_id, target_id);
-            await removeMyselfFromSharedActivities(actor_id, target_id)
+            await this.block('user', actor_id, target_id);
+            await this.removeMyselfFromSharedActivities(actor_id, target_id)
         } else {
             console.error(`Blocker "${actor_id}" or blocked "${target_id}" does not exist`);
         }
-    });
+    }
 
-export const newReportedActivity = functions.firestore
-    .document('activity_report/{reportId}').onCreate(async (snap, context) => {
-        const { actor_id, target_id } = getReportIds('report_by_id', 'reported_activity_id', snap);
+    newReportedActivity = async (snap: FirebaseFirestore.DocumentSnapshot, context: EventContext) => {
+        const { actor_id, target_id } = this.getReportIds('report_by_id', 'reported_activity_id', snap);
         if(actor_id && target_id){
-            await block('activity', actor_id, target_id);
-            const ref = Ref(db).activities().doc(target_id)
-            await updateActivityOnBlock(ref, actor_id)
+            await this.block('activity', actor_id, target_id);
+            const ref = Ref(this.db).activities().doc(target_id)
+            await this.updateActivityOnBlock(ref, actor_id)
         } else {
             console.error(`Blocker "${actor_id}" or blocked "${target_id}" does not exist`);
         }
-    });
+    }
 
-// We want to remove ME from evry activity I share with "blockedUser"
- async function removeMyselfFromSharedActivities(me: string, blockedUser: string): Promise<void> {
-     // Query for all activities which I am in. Note that we cannot
-     // chain array-contains to include multiple values
-    const query = Ref(db).activities().where('members', 'array-contains', me)
-    const results = await query.get()
+    getReportIds = (actorField: string, targetField: string, snap: FirebaseFirestore.DocumentSnapshot) => {
+        const newReport = snap.data();
+        const actor_id = newReport ? newReport[actorField] : null;
+        const target_id = newReport ? newReport[targetField] : null;
+        return { actor_id, target_id };
+    }
 
-    // Find all of my activities which include the blocked user
-    const matchingActivities = results.docs.filter( doc => {
-        const data = doc.data()
-        const members = get(data, 'members', []) as string[]
-        return includes(members, blockedUser)
-    })
-    
-    // Handle remove/ban on each shared activity:
-    const tasks = matchingActivities.map( ({ ref }) => updateActivityOnBlock(ref, me) )
-    
-    // Execute all update tasks in parallel
-    await Promise.all(tasks)
-}
+    // We want to remove ME from evry activity I share with "blockedUser"
+    removeMyselfFromSharedActivities = async (me: string, blockedUser: string) => {
+        // Query for all activities which I am in. Note that we cannot
+        // chain array-contains to include multiple values
+        const query = Ref(this.db).activities().where('members', 'array-contains', me)
+        const results = await query.get()
 
-// When we report/block an activity, or report/block a user in the activity, we want to:
-// 1) remove ourselves from the activity and 2) ban ourselves from the activity.
-async function updateActivityOnBlock(activityRef: FirebaseFirestore.DocumentReference, me: string): Promise<void> {
-    // Remove myself from members; add myself to ban list:
-    await activityRef.update({
-        members: admin.firestore.FieldValue.arrayRemove(me),
-        banned_users: admin.firestore.FieldValue.arrayUnion(me)
-    })
+        // Find all of my activities which include the blocked user
+        const matchingActivities = results.docs.filter( doc => {
+            const data = doc.data()
+            const members = get(data, 'members', []) as string[]
+            return includes(members, blockedUser)
+        })
+        
+        // Handle remove/ban on each shared activity:
+        const tasks = matchingActivities.map( ({ ref }) => this.updateActivityOnBlock(ref, me) )
+        
+        // Execute all update tasks in parallel
+        await Promise.all(tasks)
+    }
+
+    // When we report/block an activity, or report/block a user in the activity, we want to:
+    // 1) remove ourselves from the activity and 2) ban ourselves from the activity.
+    updateActivityOnBlock = async (activityRef: FirebaseFirestore.DocumentReference, me: string) => {
+        // Remove myself from members; add myself to ban list:
+        await activityRef.update({
+            members: admin.firestore.FieldValue.arrayRemove(me),
+            banned_users: admin.firestore.FieldValue.arrayUnion(me)
+        })
+    }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,7 +8,11 @@ const settings = { timestampsInSnapshots: true }
 admin.firestore().settings(settings)
 
 // Export all cloud functions from this file:
-export * from './blocking'
+import Blocking from './blocking'
+const blocking = new Blocking(admin.firestore())
+export const blockUserOnCall = functions.https.onCall(blocking.blockUserOnCall)
+export const newReportedUser = functions.firestore.document('user_report/{reportId}').onCreate(blocking.newReportedUser)
+export const newReportedActivity = functions.firestore.document('activity_report/{reportId}').onCreate(blocking.newReportedActivity)
 
 import Notifications from './notifications'
 const notifications = new Notifications(

--- a/functions/src/test/blocking.test.ts
+++ b/functions/src/test/blocking.test.ts
@@ -1,9 +1,15 @@
 import * as assert from 'assert';
 import * as admin from 'firebase-admin';
 import 'mocha';
-import * as blocking from '../blocking';
+import Blocking from '../blocking';
 import { FeaturesList } from 'firebase-functions-test/lib/features';
 import { getTestFeatureList } from './config';
+import * as mocks from './mocks'
+import * as sinon from 'sinon'
+
+// Ideally, we would use the mock for this, but we want to make sure our existing tests keep working:
+admin.initializeApp()
+const blocking = new Blocking(admin.firestore())
 
 describe("Block function", () => {
 
@@ -113,7 +119,24 @@ describe("IDs are properly taken from snapshots", () => {
     })
 })
 
+describe('Remove myself from shared activities', () => {
+    it('Filters based on members', async () => {
+        const mockBlocking = new Blocking(mocks.firestoreMock)
+        const me = 'me'
+        const blockedUser = 'them'
+        const spy = sinon.spy(mockBlocking, 'updateActivityOnBlock')
+        await mockBlocking.removeMyselfFromSharedActivities(me, blockedUser)
+        assert(spy.calledOnce)
+    })
+})
 
-
-
-
+describe('Update activity on block', () => {
+    it('Calls update on the given ref', async () => {
+        const mockBlocking = new Blocking(mocks.firestoreMock)
+        const spy = sinon.spy(mocks, 'activityUpdateSpy')
+        const mockRef = mocks.generateRef("hello")
+        // @ts-ignore
+        await mockBlocking.updateActivityOnBlock(mockRef.ref, 'me')
+        assert(spy.calledOnce)
+    })
+})

--- a/functions/src/test/mocks.ts
+++ b/functions/src/test/mocks.ts
@@ -193,6 +193,20 @@ export const mockActivity = {
         end_time : new Date(),
         topic_ids : ['security'],
         date_created : new Date(),
+    },
+    another_act: {
+        location : {
+            latitude: 10,
+            longitude: 10.5
+        },
+        members : ['bob', 'them'],
+        owner_id : ['alice'],
+        title : 'Security Meetup',
+        description : 'We\'ll do security!',
+        start_time : new Date(),
+        end_time : new Date(),
+        topic_ids : ['security'],
+        date_created : new Date(),
     }
 }
 
@@ -267,7 +281,23 @@ function collectionGenerator(data: {[id: string]: Object}) {
             }),
             delete: async () => { exports.spyOnMe1(); return true }
         }),
-        add: (d: any) => Promise.resolve(d)
+        add: (d: any) => Promise.resolve(d),
+        where: (query1: string, query2: string, info: string) => ({
+            get: () => Promise.resolve({ docs: [
+                generateRef(mockActivity.another_act),
+                generateRef(mockActivity.default)
+            ] })
+        })
+    }
+}
+
+export const activityUpdateSpy = (args: any) => undefined
+export function generateRef( data: any ) {
+    return {
+        data: () => data,
+        ref: {
+            update: (args: any) => Promise.resolve(exports.activityUpdateSpy(args))
+        }
     }
 }
 


### PR DESCRIPTION
This is already deployed and I've tested that it works when reporting a user in the app.

### Edit: I added these things too:
- When you report an activity, you are now added to its banned list
- When you report an activity, you are now removed from it if you were already in it
- When you block a user, you are added to the ban list of each activity you share with that user
- (And, as in the original PR) when you block a user, you are removed from each activity you share with them.

_Note: These are deployed, and I tested each of those situations with different conditions: e.g. what happens when you block someone, but you *aren't* joined, etc_

I should add tests to keep us > 80%.
- [x] Add tests.