### PR TITLE
Fix sorting of reports

### DIFF
--- a/web-dev/Reports.tsx
+++ b/web-dev/Reports.tsx
@@ -87,10 +87,12 @@ const getReportsdByUser: ((r: Report[]) => _.Dictionary<Report[] | undefined>) =
     memoizeOne((userReports: Report[]) => _.keyBy(groupReports(userReports, r => r.report_by_id), r => r[0].report_by_id));
 
 function groupReports<T>(reports: Report[], toGroupBy: (r: Report) => any): Report[][] {
+    // Grab grouped reports sorted by 
+    //  number of reports for this object
+    //  and then by latestReportTimestamp.
     return _(reports)
         .groupBy(toGroupBy)
-        .orderBy(r => r.length, "desc")
-        .orderBy(latestReportTimestamp, "desc")
+        .orderBy([r => r.length, latestReportTimestamp], ["desc", "desc"])
         .value() as Report[][];
 }
 

--- a/web-dev/package-lock.json
+++ b/web-dev/package-lock.json
@@ -6787,6 +6787,11 @@
         "statuses": "~1.4.0"
       }
     },
+    "sentiment": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sentiment/-/sentiment-5.0.1.tgz",
+      "integrity": "sha512-MSYs0mZKrBSsRTzou2hKlWuM6jQAm0AtFqAVtaRlqxjaxCTlVwTMz65VDeW9ov3aCcPM0Cvxcn5JnBo1mtreqg=="
+    },
     "serialize-javascript": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",

--- a/web-dev/package.json
+++ b/web-dev/package.json
@@ -45,6 +45,7 @@
     "react-redux": "^6.0.1",
     "react-use-localstorage": "^3.0.0",
     "redux": "^4.0.1",
+    "sentiment": "^5.0.1",
     "short-number": "^1.0.6"
   }
 }

--- a/web-dev/style.scss
+++ b/web-dev/style.scss
@@ -126,7 +126,7 @@ textarea {
             color: red;
             background-color: white;
         }
-        button:hover {
+        button:hover, button:focus {
             background-color: red;
             color: white;
         }


### PR DESCRIPTION
Makes it so reports are ordered correctly.

To test
- View reports
- observe that they are actually sorted how it says they should be (by number of reports, and then latest)